### PR TITLE
メインイベントを検索できるようにしました．

### DIFF
--- a/pages/serch/index.vue
+++ b/pages/serch/index.vue
@@ -10,6 +10,7 @@
           <th><button @click="setCategoryFlag('food')">食べ物</button></th>
           <th><button @click="setCategoryFlag('stage')">ステージイベント</button></th>
           <th><button @click="setCategoryFlag('experience')">体験型</button></th>
+          <th><button @click="setCategoryFlag('exhibition')">展示</button></th>
         </tr>
       </table>
       <table>
@@ -78,6 +79,9 @@ export default {
           break;
         case 'main':
           this.message="メインイベント"
+          break;
+        case 'exhibition':
+          this.message="展示";
           break;
         default:
           this.message="error";


### PR DESCRIPTION
### categoryにmainを加えました
花火大会とか〇〇踊りとかはステージイベントと区別するべきだと考えたので新しくメインイベントを定義しました．
検索画面からの検索も可能です．